### PR TITLE
Fix project page date display

### DIFF
--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -42,6 +42,8 @@
       <p>{{ post.type }}, <i>{{ post.venue }}</i>, {{ post.date | default: "1900-01-01" | date: "%Y" }}</p>
     {% elsif post.collection == 'publications' %}
       <p>Published in <i>{{ post.venue }}</i>, {{ post.date | default: "1900-01-01" | date: "%Y" }}</p>
+    {% elsif post.collection == 'projects' %}
+      <p class="page__date"><strong><i class="fa fa-fw fa-calendar" aria-hidden="true"></i> Period:</strong> {{ post.project_duration }}</p>
     {% elsif post.date %}
       <p class="page__date"><strong><i class="fa fa-fw fa-calendar" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Published:" }}</strong>
       <time datetime="{{ post.date | default: "1900-01-01" | date_to_xmlschema }}">{{ post.date | default: "1900-01-01" | date: "%B %d, %Y" }}</time></p>

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -30,17 +30,21 @@ layout: default
           {% if page.read_time %}
             <p class="page__meta"><i class="fa fa-clock" aria-hidden="true"></i> {% include read-time.html %}</p>
           {% endif %}
-        {% if page.modified %}
+        {% if page.collection == 'projects' %}
+          <p class="page__date"><strong><i class="fa fa-fw fa-calendar" aria-hidden="true"></i> Period:</strong> {{ page.project_duration }}</p>
+        {% elsif page.modified %}
           <p class="page__date"><strong><i class="fa fa-fw fa-calendar" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Published:" }}</strong> <time datetime="{{ page.modified | date: "%Y-%m-%d" }}">{{ page.modified | date: "%B %d, %Y" }}</time></p>
         {% endif %}
         
         {% if page.collection == 'teaching' %}
           <p> {{ page.type }}, <i>{{ page.venue }}</i>, {{ page.date | default: "1900-01-01" | date: "%Y" }} </p>
+        {% elsif page.collection == 'projects' %}
+          {% comment %}Date handled above for projects{% endcomment %}
         {% elsif page.venue and page.date %}
           <p>Published in <i>{{ page.venue }}</i>, {{ page.date | default: "1900-01-01" | date: "%Y" }} </p>
         {% elsif page.date %}
           <p class="page__date"><strong><i class="fa fa-fw fa-calendar" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Published:" }}</strong> <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | default: "1900-01-01" | date: "%B %d, %Y" }}</time></p>
-        {% endif %}    
+        {% endif %}
         </header>
       {% endunless %}
 

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -5,6 +5,16 @@ permalink: /projects/
 author_profile: true
 ---
 
+## Current Projects
 {% for post in site.projects reversed %}
-  {% include archive-single.html %}
+  {% if post.project_duration contains 'Present' %}
+    {% include archive-single.html %}
+  {% endif %}
+{% endfor %}
+
+## Past Projects
+{% for post in site.projects reversed %}
+  {% unless post.project_duration contains 'Present' %}
+    {% include archive-single.html %}
+  {% endunless %}
 {% endfor %}


### PR DESCRIPTION
## Summary
- show project durations instead of publish dates in project listings
- show project durations on individual project pages
- group projects into Current and Past sections

## Testing
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685053b8722c832f949c2dd750892eb0