### PR TITLE
Fix patent category headings

### DIFF
--- a/_pages/patents.md
+++ b/_pages/patents.md
@@ -13,7 +13,7 @@ author_profile: true
         {% continue %}
       {% endif %}
       {% unless title_shown %}
-        <h2>{{ category[1].title }}</h2><hr />
+<h2>{{ category[1].title }}</h2><hr />
         {% assign title_shown = true %}
       {% endunless %}
       {% include archive-single.html %}


### PR DESCRIPTION
## Summary
- ensure patent category headings are parsed as HTML instead of code blocks

## Testing
- `bundle exec jekyll build` *(fails: bundler not found)*
- `bundle install` *(fails: 403 Forbidden)*
- `npm run build:js` *(fails: uglifyjs not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850562cf628832f897d384f74e0ccd6