### PR TITLE
Fix navigation item visibility

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -13,7 +13,7 @@
             {% else %}
               {% assign domain = base_path %}
             {% endif %}
-            <li class="masthead__menu-item"><a href="{{ domain }}{{ link.url }}">{{ link.title }}</a></li>
+            <li class="masthead__menu-item persist"><a href="{{ domain }}{{ link.url }}">{{ link.title }}</a></li>
           {% endfor %}
           <li id="theme-toggle" class="masthead__menu-item persist tail">
             <a><i id="theme-icon" class="fa-solid fa-sun" aria-hidden="true" title="toggle theme"></i></a>


### PR DESCRIPTION
## Summary
- ensure masthead navigation links persist across pages

## Testing
- `npm run build:js` *(fails: uglifyjs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68505bfb6160832fa9cfeb9616b22ce1